### PR TITLE
feat(questions): Titel-Feld in UI einbauen + Lehrer-Filter und Titel-Suche

### DIFF
--- a/SpotAnalysis.Services.Tests/seed.sql
+++ b/SpotAnalysis.Services.Tests/seed.sql
@@ -1,8 +1,8 @@
 INSERT INTO dbo.Users (UserName, UserID, PasswordHash, Roles) VALUES
     ('Lehrer1', '9c9c2138-f945-41fa-823e-f3bd286c0fa1', '$argon2id$v=19$m=4096,t=4,p=4$OWM5YzIxMzgtZjk0NS00MWZhLTgyM2UtZjNiZDI4NmMwZmEx$yIGUKh8n1+NddBGL4BbTZq1sxVhZlWh1p4DlYPccmWM', '[1]'),
-    ('Lehrer2', '48bb93c8-214f-47f0-910f-9056b19de94a', '$argon2id$v=19$m=4096,t=4,p=4$NDhiYjkzYzgtMjE0Zi00N2YwLTkxMGYtOTA1NmIxOWRlOTRh$cnenEgTM0DfaIHBN6JMFMFAWQ00p3tu4m75Ob4wgFTk', '[]'),
-    ('Schueler1', '2195c82c-0a67-4938-9c88-20c089276da5', '$argon2id$v=19$m=4096,t=4,p=4$MjE5NWM4MmMtMGE2Ny00OTM4LTljODgtMjBjMDg5Mjc2ZGE1$dpiG9escRjHIzOTYTM0hQOBnSWb0mQzHOenq8IoUQ7Q', '[]'),
-    ('Schueler2', 'f01c1e4f-c5e0-4f77-a3b3-f59f8b837553', '$argon2id$v=19$m=4096,t=4,p=4$ZjAxYzFlNGYtYzVlMC00Zjc3LWEzYjMtZjU5ZjhiODM3NTUz$ui1HyahZiikGT1Rd8XIeu8JeSJNaw42QHoM5a++sgO8', '[]');
+    ('Lehrer2', '48bb93c8-214f-47f0-910f-9056b19de94a', '$argon2id$v=19$m=4096,t=4,p=4$NDhiYjkzYzgtMjE0Zi00N2YwLTkxMGYtOTA1NmIxOWRlOTRh$cnenEgTM0DfaIHBN6JMFMFAWQ00p3tu4m75Ob4wgFTk', '[1]'),
+    ('Schueler1', '2195c82c-0a67-4938-9c88-20c089276da5', '$argon2id$v=19$m=4096,t=4,p=4$MjE5NWM4MmMtMGE2Ny00OTM4LTljODgtMjBjMDg5Mjc2ZGE1$dpiG9escRjHIzOTYTM0hQOBnSWb0mQzHOenq8IoUQ7Q', '[2]'),
+    ('Schueler2', 'f01c1e4f-c5e0-4f77-a3b3-f59f8b837553', '$argon2id$v=19$m=4096,t=4,p=4$ZjAxYzFlNGYtYzVlMC00Zjc3LWEzYjMtZjU5ZjhiODM3NTUz$ui1HyahZiikGT1Rd8XIeu8JeSJNaw42QHoM5a++sgO8', '[2]');
 
 SET IDENTITY_INSERT dbo.Chemicals ON;
 INSERT INTO dbo.Chemicals (ChemicalID, Type, Name, Formula, Color) VALUES 

--- a/SpotAnalysis.Services/DTOs/QuestionDetailDto.cs
+++ b/SpotAnalysis.Services/DTOs/QuestionDetailDto.cs
@@ -5,6 +5,7 @@ namespace SpotAnalysis.Services.DTOs;
 public class QuestionDetailDto
 {
     public required int Id { get; init; }
+    public required string Title { get; init; }
     public required string Description { get; init; }
     public required QuestionType Type { get; init; }
     

--- a/SpotAnalysis.Services/DTOs/QuestionOverviewDto.cs
+++ b/SpotAnalysis.Services/DTOs/QuestionOverviewDto.cs
@@ -5,8 +5,10 @@ namespace SpotAnalysis.Services.DTOs;
 public class QuestionOverviewDto
 {
     public required int Id { get; set; }
+    public required string Title { get; set; }
     public required string Description { get; set; }
     public required QuestionType Type { get; set; }
+    public Guid? CreatedById { get; set; }
     public string? CreatedByName { get; set; }
     public int QuizCount { get; set; }
     

--- a/SpotAnalysis.Services/Services/QuizService.cs
+++ b/SpotAnalysis.Services/Services/QuizService.cs
@@ -327,8 +327,10 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
             .Select(q => q.Type == QuestionType.SpotTest ? new QuestionOverviewDto
             {
                 Id = q.QuestionID,
+                Title = q.Title,
                 Description = q.Description,
                 Type = q.Type,
+                CreatedById = q.CreatedBy,
                 CreatedByName = q.Creator.UserName,
                 QuizCount = q.QuizQuestions.Count,
                 ChemicalCount = q.STQuestion!.AvailableChemicals.Count,
@@ -337,8 +339,10 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
             } : new QuestionOverviewDto
             {
                 Id = q.QuestionID,
+                Title = q.Title,
                 Description = q.Description,
                 Type = q.Type,
+                CreatedById = q.CreatedBy,
                 CreatedByName = q.Creator.UserName,
                 QuizCount = q.QuizQuestions.Count,
                 ReactionCount = q.STLQuestion!.AvailableReactions.Count,
@@ -361,6 +365,7 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
                     .Select(x => new QuestionDetailDto
                     {
                         Id = x.QuestionID,
+                        Title = x.Title,
                         Description = x.Description,
                         Type = x.Type,
                         Chemicals = x.STQuestion.AvailableChemicals.Select(ac => new ChemicalQuestionDto
@@ -384,6 +389,7 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
                         .Select(x => new QuestionDetailDto
                         {
                             Id = x.QuestionID,
+                            Title = x.Title,
                             Description = x.Description,
                             Type = x.Type,
                             AvailableReactionIds = x.STLQuestion.AvailableReactions
@@ -407,8 +413,10 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
             .Select(q => q.Question.Type == QuestionType.SpotTest ? new QuestionOverviewDto
             {
                 Id = q.QuestionID,
+                Title = q.Question.Title,
                 Description = q.Question.Description,
                 Type = q.Question.Type,
+                CreatedById = q.Question.CreatedBy,
                 CreatedByName = q.Question.Creator.UserName,
                 QuizCount = q.Question.QuizQuestions.Count,
                 ChemicalCount = q.Question.STQuestion!.AvailableChemicals.Count,
@@ -417,8 +425,10 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
             } : new QuestionOverviewDto
             {
                 Id = q.QuestionID,
+                Title = q.Question.Title,
                 Description = q.Question.Description,
                 Type = q.Question.Type,
+                CreatedById = q.Question.CreatedBy,
                 CreatedByName = q.Question.Creator.UserName,
                 QuizCount = q.Question.QuizQuestions.Count,
                 ReactionCount = q.Question.STLQuestion!.AvailableReactions.Count,
@@ -516,6 +526,7 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
         if (existing?.STQuestion is null)
             throw new KeyNotFoundException($"SpotTest question with id {question.Id} not found.");
 
+        existing.Title = question.Title;
         existing.Description = question.Description;
 
         await dbContext.STAvailableChemicals
@@ -560,6 +571,7 @@ public class QuizService(ILogger<QuizService> logger, IDbContextFactory<Analysis
         if (existing?.STLQuestion is null)
             throw new KeyNotFoundException($"Question with id {question.Id} not found.");
 
+        existing.Title = question.Title;
         existing.Description = question.Description;
         existing.STLQuestion.ReactionID = question.ReactionId;
         existing.STLQuestion.ShownEductID = question.ShowEductId;

--- a/SpotAnalysis.Web/Components/Pages/Teacher/QuestionEditor.razor
+++ b/SpotAnalysis.Web/Components/Pages/Teacher/QuestionEditor.razor
@@ -24,6 +24,15 @@
             </div>
         </div>
 
+        @* Title *@
+        <div class="mb-4">
+            <label class="form-label-custom">Titel</label>
+            <p class="hint-text">Interner Titel (nur für Lehrer sichtbar, nicht für Schüler)</p>
+            <input type="text" class="form-control input-custom"
+                   placeholder="z.B. Tüpfeln Q1 - drei Unbekannte"
+                   @bind="_title" />
+        </div>
+
         @* Description *@
         <div class="mb-4">
             <label class="form-label-custom">Beschreibung / Aufgabenstellung</label>
@@ -52,6 +61,7 @@
                         }
                     </div>
                     <select class="form-select form-select-sm input-custom"
+                            value=""
                             @onchange="OnEductSelected">
                         <option value="">+ Edukt hinzufügen...</option>
                         @foreach (var chem in _eductsAvailable.Where(c => !_selectedEducts.Any(s => s.Id == c.Id)))
@@ -77,6 +87,7 @@
                         }
                     </div>
                     <select class="form-select form-select-sm input-custom"
+                            value=""
                             @onchange="OnAdditiveSelected">
                         <option value="">+ Zusatzstoff hinzufügen...</option>
                         @foreach (var chem in _additivesAvailable.Where(c => !_selectedAdditives.Any(s => s.Id == c.Id)))
@@ -102,6 +113,7 @@
                         }
                     </div>
                     <select class="form-select form-select-sm input-custom"
+                            value=""
                             @onchange="OnMethodSelected">
                         <option value="">+ Methode hinzufügen...</option>
                         @foreach (var method in _allMethods.Where(m => !_selectedMethods.Any(s => s.Id == m.Id)))
@@ -169,6 +181,7 @@
                         }
                     }
                     <select class="form-select form-select-sm input-custom mt-2"
+                            value=""
                             @onchange="OnDistractorSelected">
                         <option value="">+ Reaktion als Auswahloption hinzufügen...</option>
                         @foreach (var reaction in _allReactions.Where(r =>
@@ -208,6 +221,7 @@
 
     private bool _isEdit => QuestionId.HasValue;
     private QuestionType _questionType = QuestionType.SpotTest;
+    private string _title = "";
     private string _description = "";
 
     // SpotTest state
@@ -229,7 +243,7 @@
     private string? _errorMessage;
 
     // TODO: Replace with actual teacher ID from auth when login is implemented
-    private Guid _teacherId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private Guid _teacherId = Guid.Parse("9c9c2138-f945-41fa-823e-f3bd286c0fa1");
 
     protected override async Task OnInitializedAsync()
     {
@@ -263,6 +277,7 @@
     private async Task LoadExistingQuestion()
     {
         var detail = await QuizService.GetQuestionDetail(QuestionId!.Value);
+        _title = detail.Title;
         _description = detail.Description;
         _questionType = detail.Type;
 
@@ -335,6 +350,12 @@
     {
         _errorMessage = null;
 
+        if (string.IsNullOrWhiteSpace(_title))
+        {
+            _errorMessage = "Bitte einen Titel eingeben.";
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(_description))
         {
             _errorMessage = "Bitte eine Beschreibung eingeben.";
@@ -356,7 +377,7 @@
                     Description = _description,
                     AvailableChemicals = allChemicalIds,
                     AvailableMethods = _selectedMethods.Select(m => m.Id).ToList(),
-                    Title = "Gurkenglas" // TODO
+                    Title = _title
                 };
 
                 if (_isEdit)
@@ -385,7 +406,7 @@
                     ReactionId = _selectedReactionId,
                     ShowEductId = selectedReaction?.Chemical1ID ?? 0,
                     AvailableReactions = allReactionIds,
-                    Title = "Gurkenglas" // TODO
+                    Title = _title
                 };
 
                 if (_isEdit)

--- a/SpotAnalysis.Web/Components/Pages/Teacher/QuestionList.razor
+++ b/SpotAnalysis.Web/Components/Pages/Teacher/QuestionList.razor
@@ -17,9 +17,16 @@
     </div>
 
     @* Filter Bar *@
-    <div class="d-flex gap-2 mb-3 align-items-center">
-        <input type="text" class="form-control input-custom flex-grow-1" placeholder="Suchen..."
+    <div class="d-flex gap-2 mb-3 align-items-center flex-wrap">
+        <input type="text" class="form-control input-custom flex-grow-1" placeholder="Suchen (Titel oder Beschreibung)..."
                @bind="_searchTerm" @bind:event="oninput" />
+        <select class="form-select input-custom" style="width: auto;" @bind="_teacherFilter">
+            <option value="">Alle Lehrer</option>
+            @foreach (var teacher in AvailableTeachers)
+            {
+                <option value="@teacher.Id">@teacher.Name</option>
+            }
+        </select>
         <button class="btn btn-pill @(_typeFilter is null ? "active" : "")"
                 @onclick="() => _typeFilter = null">Alle</button>
         <button class="btn btn-pill @(_typeFilter == QuestionType.SpotTest ? "active" : "")"
@@ -55,7 +62,8 @@
                                 <small class="text-muted">von @q.CreatedByName</small>
                             }
                         </div>
-                        <div class="fw-semibold">@q.Description</div>
+                        <div class="fw-semibold">@q.Title</div>
+                        <div class="text-muted small mb-1">@q.Description</div>
                         <small class="text-muted">
                             @if (q.Type == QuestionType.SpotTest)
                             {
@@ -97,7 +105,7 @@
                         }
                         else
                         {
-                            <p>Möchtest du die Frage <strong>"@_questionToDelete.Description"</strong> wirklich löschen?</p>
+                            <p>Möchtest du die Frage <strong>"@_questionToDelete.Title"</strong> wirklich löschen?</p>
                         }
                     </div>
                     <div class="modal-footer border-0">
@@ -125,6 +133,7 @@
     private List<QuestionOverviewDto>? _questions;
     private string _searchTerm = "";
     private QuestionType? _typeFilter;
+    private string _teacherFilter = "";
     private QuestionOverviewDto? _questionToDelete;
     private string? _deleteError;
 
@@ -133,10 +142,24 @@
         _questions = await QuizService.GetQuestions();
     }
 
+    private record TeacherOption(string Id, string Name);
+
+    private IEnumerable<TeacherOption> AvailableTeachers =>
+        _questions is null
+            ? []
+            : _questions
+                .Where(q => q.CreatedById.HasValue && !string.IsNullOrEmpty(q.CreatedByName))
+                .Select(q => new TeacherOption(q.CreatedById!.Value.ToString(), q.CreatedByName!))
+                .DistinctBy(t => t.Id)
+                .OrderBy(t => t.Name);
+
     private IEnumerable<QuestionOverviewDto> FilteredQuestions =>
         _questions?.Where(q =>
             (_typeFilter is null || q.Type == _typeFilter) &&
+            (string.IsNullOrEmpty(_teacherFilter) ||
+             q.CreatedById?.ToString() == _teacherFilter) &&
             (string.IsNullOrEmpty(_searchTerm) ||
+             q.Title.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase) ||
              q.Description.Contains(_searchTerm, StringComparison.OrdinalIgnoreCase))
         ) ?? [];
 

--- a/SpotAnalysis.Web/Components/Pages/Teacher/QuizEditor.razor
+++ b/SpotAnalysis.Web/Components/Pages/Teacher/QuizEditor.razor
@@ -144,7 +144,7 @@
     private string? _errorMessage;
 
     // TODO: Replace with actual teacher ID from auth when login is implemented
-    private Guid _teacherId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private Guid _teacherId = Guid.Parse("9c9c2138-f945-41fa-823e-f3bd286c0fa1");
 
     protected override async Task OnInitializedAsync()
     {

--- a/SpotAnalysis.Web/Components/Pages/Teacher/QuizList.razor
+++ b/SpotAnalysis.Web/Components/Pages/Teacher/QuizList.razor
@@ -88,7 +88,7 @@
     private QuizOverviewDto? _quizToDelete;
 
     // TODO: Replace with actual teacher ID from auth when login is implemented
-    private Guid _teacherId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private Guid _teacherId = Guid.Parse("9c9c2138-f945-41fa-823e-f3bd286c0fa1");
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
  - QuestionEditor: Pflicht-Input für Titel (ersetzt "Gurkenglas"-Dummy)
  - QuestionList: Titel anzeigen, Suche matcht Titel + Beschreibung, neuer Lehrer-Dropdown-Filter
  - DTOs: Title in QuestionOverviewDto/QuestionDetailDto ergänzt, CreatedById in QuestionOverviewDto für Lehrer-Filter
  - QuizService: Title beim Update persistieren, CreatedById projizieren
  - Teacher-Pages: Dummy-GUID durch geseedete Lehrer1-GUID ersetzt, behebt FK-Violation beim Quiz/Question-Erstellen
  - seed.sql: Lehrer2/Schueler1/Schueler2 Rollen korrigiert