### PR TITLE
feat: seed dev users on startup in Development environment

### DIFF
--- a/SpotAnalysis.Data/SpotAnalysis.Data.csproj
+++ b/SpotAnalysis.Data/SpotAnalysis.Data.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Folder Include="Data\Migrations\" />
+    <Folder Include="Migrations\" />
   </ItemGroup>
 
 </Project>

--- a/SpotAnalysis.Services/ServiceCollectionExtensions.cs
+++ b/SpotAnalysis.Services/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<IAdminService, AdminService>();
         services.AddScoped<IChemistryDataService, ChemistryDataService>();
+        services.AddScoped<IDatabaseSeeder, DatabaseSeeder>();
 
         return services;
     }

--- a/SpotAnalysis.Services/Services/DatabaseSeeder.cs
+++ b/SpotAnalysis.Services/Services/DatabaseSeeder.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SpotAnalysis.Data;
+using SpotAnalysis.Data.Enums;
+using SpotAnalysis.Data.Models.Identity;
+
+namespace SpotAnalysis.Services.Services;
+
+public class DatabaseSeeder(
+    ILogger<DatabaseSeeder> logger,
+    IDbContextFactory<AnalysisContext> factory) : IDatabaseSeeder
+{
+    private const string DevPassword = "!Password1";
+
+    private static readonly (string UserName, Guid UserId, Role[] Roles)[] DevUsers =
+    [
+        ("Lehrer1",   new Guid("11111111-1111-1111-1111-111111111111"), [Role.Student, Role.Teacher]),
+        ("Lehrer2",   new Guid("22222222-2222-2222-2222-222222222222"), [Role.Student, Role.Teacher]),
+        ("Lehrer3",   new Guid("33333333-3333-3333-3333-333333333333"), [Role.Student, Role.Teacher]),
+        ("Schueler1", new Guid("44444444-4444-4444-4444-444444444444"), [Role.Student]),
+        ("Schueler2", new Guid("55555555-5555-5555-5555-555555555555"), [Role.Student]),
+        ("Schueler3", new Guid("66666666-6666-6666-6666-666666666666"), [Role.Student]),
+    ];
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = await factory.CreateDbContextAsync(cancellationToken);
+
+        var devUserNames = DevUsers.Select(u => u.UserName).ToArray();
+        var existing = await context.Users
+            .Where(u => devUserNames.Contains(u.UserName))
+            .Select(u => u.UserName)
+            .ToListAsync(cancellationToken);
+
+        var added = 0;
+        foreach (var (userName, userId, roles) in DevUsers)
+        {
+            if (existing.Contains(userName)) continue;
+
+            var user = new User
+            {
+                UserID = userId,
+                UserName = userName,
+                PasswordHash = new PasswordProvider.Password(DevPassword, userId).ParamString(),
+            };
+            foreach (var role in roles) user.Roles.Add(role);
+            context.Users.Add(user);
+            added++;
+        }
+
+        if (added == 0)
+        {
+            logger.LogInformation("Dev data seeder: all {Total} users already present", DevUsers.Length);
+            return;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Dev data seeder added {Count}/{Total} users", added, DevUsers.Length);
+    }
+}

--- a/SpotAnalysis.Services/Services/IDatabaseSeeder.cs
+++ b/SpotAnalysis.Services/Services/IDatabaseSeeder.cs
@@ -1,0 +1,6 @@
+namespace SpotAnalysis.Services.Services;
+
+public interface IDatabaseSeeder
+{
+    Task SeedAsync(CancellationToken cancellationToken = default);
+}

--- a/SpotAnalysis.Web/Program.cs
+++ b/SpotAnalysis.Web/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 using SpotAnalysis.Services;
+using SpotAnalysis.Services.Services;
 using SpotAnalysis.Web.Components;
 using SpotAnalysis.Web.Extensions;
 
@@ -7,7 +8,7 @@ namespace SpotAnalysis.Web;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
 
@@ -35,6 +36,19 @@ public class Program
         {
             app.UseExceptionHandler("/Error");
             app.UseHsts();
+        }
+        else
+        {
+            await using var scope = app.Services.CreateAsyncScope();
+            var seeder = scope.ServiceProvider.GetRequiredService<IDatabaseSeeder>();
+            try
+            {
+                await seeder.SeedAsync();
+            }
+            catch (Exception ex)
+            {
+                app.Logger.LogError(ex, "Dev data seeding failed (database not migrated yet?)");
+            }
         }
 
         app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);


### PR DESCRIPTION
  Adds DatabaseSeeder that creates 3 teachers (Lehrer1-3) and 3 students
  (Schueler1-3) with shared password "!Password1" on first run, so
  developers can log in without manually registering users. Idempotent
  by username and only runs when ASPNETCORE_ENVIRONMENT=Development.
  Hashes are produced via the existing PasswordProvider using fixed
  per-user GUIDs as Argon2id salt.